### PR TITLE
Configure deployment to trigger only on semver git tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,9 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   id-token: write

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -18,11 +18,12 @@ const domainName = `${subDomain}.${fullyQualifiedDomain}`;
 
 // OIDC stack - Creates GitHub OIDC provider and IAM role for GitHub Actions
 // This should be deployed first, before other stacks
+// Configured to only allow deployments from semver tags (v*.*.*)
 new OidcStack(app, "PstrOidcStack", {
   env,
   githubOrg: "lukewiwa",
   githubRepo: "pwa-share-target-data-revealer",
-  githubBranches: ["master"],
+  githubTagPatterns: ["v*"],
 });
 
 // DNS stack - Route53 is global, but we create it in the primary region

--- a/infra/lib/oidc-stack.ts
+++ b/infra/lib/oidc-stack.ts
@@ -14,10 +14,11 @@ export interface OidcStackProps extends StackProps {
   readonly githubRepo: string;
 
   /**
-   * GitHub branches that can assume the role
-   * @default - ["master"]
+   * GitHub tag patterns that can assume the role
+   * Supports wildcards (e.g., ["v*"] for all tags starting with 'v')
+   * @default - ["v*"]
    */
-  readonly githubBranches?: string[];
+  readonly githubTagPatterns?: string[];
 }
 
 export class OidcStack extends Stack {
@@ -27,7 +28,7 @@ export class OidcStack extends Stack {
     super(scope, id, props);
 
     const { githubOrg, githubRepo } = props;
-    const githubBranches = props.githubBranches ?? ["master"];
+    const githubTagPatterns = props.githubTagPatterns ?? ["v*"];
 
     // Create the GitHub OIDC provider
     const githubProvider = new iam.OpenIdConnectProvider(
@@ -49,9 +50,9 @@ export class OidcStack extends Stack {
             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
           },
           StringLike: {
-            "token.actions.githubusercontent.com:sub": githubBranches.map(
-              (branch) =>
-                `repo:${githubOrg}/${githubRepo}:ref:refs/heads/${branch}`
+            "token.actions.githubusercontent.com:sub": githubTagPatterns.map(
+              (tagPattern) =>
+                `repo:${githubOrg}/${githubRepo}:ref:refs/tags/${tagPattern}`
             ),
           },
         },


### PR DESCRIPTION
- Update GitHub Actions workflow to trigger on semver tags (v*.*.* format)
- Modify OIDC stack to allow tag-based deployments instead of branch-based
- Support both standard semver tags (v1.0.0) and pre-release tags (v1.0.0-beta)
- Remove branch-based deployment trigger from master branch

This ensures deployments only occur when version tags are pushed,
providing better control over production releases.